### PR TITLE
Change to Debian to avoid errors when building deb

### DIFF
--- a/origins/debian
+++ b/origins/debian
@@ -1,3 +1,3 @@
-Vendor: LingmoOS
+Vendor: Debian
 Vendor-URL: https://lingmo.org/
 Bugs: debbugs://bugs.lingmo.org


### PR DESCRIPTION
Yeps. Perl script only  know Debian rather than LingmoOS(x